### PR TITLE
In memory version of the test application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ target/
 
 .idea/
 *.iml
+
+*.class
+build/

--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ CREATE TABLE `__GROUP`
   `id`       int(11) NOT NULL AUTO_INCREMENT,
   `name`     varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `parentId` int(11)                              DEFAULT NULL,
+  `topLevelId` int(11)                            DEFAULT NULL,
   
   PRIMARY KEY (`id`),
   UNIQUE KEY `IDX_GROUP_TITLE` (`name`),
   KEY `IDX_PARENT_ID` (`parentId`),
-  CONSTRAINT `fk_groups_group_id` FOREIGN KEY (`parentId`) REFERENCES `__GROUP` (`id`)
+  CONSTRAINT `fk_groups_group_id` FOREIGN KEY (`parentId`) REFERENCES `__GROUP` (`id`),
+  FOREIGN KEY (`topLevelId`) REFERENCES `__GROUP` (`id`)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8
   COLLATE = utf8_unicode_ci
@@ -40,3 +42,11 @@ So, we need to make any necessary changes to eliminate the need of the cache. Su
 
 1. Changes in the database structure
 2. Changes in the Java code
+
+## Run
+This is an in memory version. You can:
+
+```bash
+javac -cp ./src/ -d build src/test/hierarchy/Application.java
+java -cp ./build/ test.hierarchy.Application
+```

--- a/src/test/hierarchy/Application.java
+++ b/src/test/hierarchy/Application.java
@@ -1,0 +1,17 @@
+package test.hierarchy;
+
+import test.hierarchy.dao.GroupDao;
+import test.hierarchy.dao.GroupDaoImpl;
+import test.hierarchy.service.GroupService;
+import test.hierarchy.service.GroupServiceImpl;
+import test.hierarchy.service.MockData;
+
+public class Application {
+    public static void main(String[] args) {
+        GroupDao groupRepository = new GroupDaoImpl(new MockData());
+        GroupService groupService = new GroupServiceImpl(groupRepository);
+        var group = groupService.getGroupById(1);
+        var topLevel = groupService.getTopLevelGroupId(5);
+        System.out.println("Top Level " + topLevel);
+    }
+}

--- a/src/test/hierarchy/GroupModel.java
+++ b/src/test/hierarchy/GroupModel.java
@@ -2,7 +2,9 @@ package test.hierarchy;
 
 import test.hierarchy.domain.Group;
 
-import java.util.*;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Author: Meletis Margaritis

--- a/src/test/hierarchy/dao/GroupDaoImpl.java
+++ b/src/test/hierarchy/dao/GroupDaoImpl.java
@@ -1,0 +1,30 @@
+package test.hierarchy.dao;
+
+import test.hierarchy.domain.Group;
+import test.hierarchy.service.MockData;
+
+import java.util.List;
+
+public class GroupDaoImpl implements GroupDao {
+    private final List<Group> groups;
+    private final MockData mockData;
+
+    public GroupDaoImpl(MockData mockData) {
+        this.mockData = mockData;
+        groups = mockData.getData();
+    }
+
+    @Override
+    public List<Group> getAllGroups() {
+        return groups;
+    }
+
+    @Override
+    public Group getGroupById(Integer groupId) {
+        if(groupId == null) {
+            throw new IllegalArgumentException("groupId should not be null");
+        }
+
+        return groups.stream().filter(g -> g.getId().equals(groupId)).findFirst().orElseThrow();
+    }
+}

--- a/src/test/hierarchy/domain/Group.java
+++ b/src/test/hierarchy/domain/Group.java
@@ -8,6 +8,14 @@ public class Group {
     private Integer id;
     private String name;
     private Integer parentId;
+    private Integer topLevelId;
+
+    public Group(Integer id, String name, Integer parentId, Integer topLevelId) {
+        this.id = id;
+        this.name = name;
+        this.parentId = parentId;
+        this.topLevelId = topLevelId;
+    }
 
     public Integer getId() {
         return id;
@@ -31,5 +39,13 @@ public class Group {
 
     public void setParentId(Integer parentId) {
         this.parentId = parentId;
+    }
+
+    public Integer getTopLevelId() {
+        return topLevelId;
+    }
+
+    public void setTopLevelId(Integer topLevelId) {
+        this.topLevelId = topLevelId;
     }
 }

--- a/src/test/hierarchy/service/GroupService.java
+++ b/src/test/hierarchy/service/GroupService.java
@@ -16,7 +16,7 @@ public interface GroupService {
      * Returns the ID of the top-level parent of the group with the given {@code groupId}.
      *
      * @param groupId the group ID of the child group.
-     * @return an ID that belongs to a top-level group, or null if none found.
+     * @return when it's already at the top level will return the same group id. In case it's root it'll return null.
      */
     Integer getTopLevelGroupId(Integer groupId);
 }

--- a/src/test/hierarchy/service/GroupServiceImpl.java
+++ b/src/test/hierarchy/service/GroupServiceImpl.java
@@ -4,8 +4,6 @@ import test.hierarchy.GroupModel;
 import test.hierarchy.dao.GroupDao;
 import test.hierarchy.domain.Group;
 
-import java.util.List;
-
 public class GroupServiceImpl implements GroupService {
 
     /**
@@ -13,13 +11,9 @@ public class GroupServiceImpl implements GroupService {
      */
     private final GroupModel cachedGroupModel = new GroupModel();
 
-    private GroupDao groupDao;
+    private final GroupDao groupDao;
 
-    public GroupDao getGroupDao() {
-        return groupDao;
-    }
-
-    public void setGroupDao(GroupDao groupDao) {
+    public GroupServiceImpl(GroupDao groupDao) {
         this.groupDao = groupDao;
     }
 
@@ -29,12 +23,8 @@ public class GroupServiceImpl implements GroupService {
             return null;
         }
 
-//        // Using the cache
-//        GroupModel groupModel = getGroupModel();
-//        return groupModel.getById(groupId);
-
         // Using the database
-        return getGroupDao().getGroupById(groupId);
+        return groupDao.getGroupById(groupId);
     }
 
     @Override
@@ -48,19 +38,13 @@ public class GroupServiceImpl implements GroupService {
         // TODO: Consider a solution that doesn't involve any cache
 
         // then we need to find the top-level group that contains that group.
-        GroupModel groupModel = getGroupModel();
-        return groupModel.findTopLevelGroupId(groupId);
-    }
 
-    protected GroupModel getGroupModel() {
-        synchronized (this) {
-            if (cachedGroupModel.isEmpty()) {
-                // TODO: consider moving this slow operation outside the synchronized block.
-                List<Group> groups = getGroupDao().getAllGroups();
-                cachedGroupModel.cache(groups);
-            }
+        try {
+            return groupDao.getGroupById(groupId).getTopLevelId();
+        }catch (Exception e) {
+            //Log exception
+            return null;
         }
-
-        return cachedGroupModel;
     }
+
 }

--- a/src/test/hierarchy/service/MockData.java
+++ b/src/test/hierarchy/service/MockData.java
@@ -1,0 +1,20 @@
+package test.hierarchy.service;
+
+import test.hierarchy.domain.Group;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MockData {
+
+    public List<Group> getData(){
+        var data = new ArrayList<Group>();
+        Group root = new Group(1, "root", null, null);
+        Group top1 = new Group(2, "Level 1", root.getId(), 2);
+        Group top2 = new Group(3, "Level 2", root.getId(), 3);
+        Group child1 = new Group(4, "Child 1", top1.getId(), top1.getId());
+        Group grandChild1 = new Group(5, "Grand Child 1", child1.getId(), top1.getId());
+        data.addAll(List.of(root, top1, top2, child1, grandChild1));
+        return data;
+    }
+}


### PR DESCRIPTION
My first thought was to implement a Union-Find algorithm with a simple improvement to avoid the trees from getting taller since that was the main issue affecting the performance in several ways. But I found this solution to be much simpler to implement giving us a 1 to 1 relation between any node and their top level parent with a 4 bytes trade off per record in memory. The following is an in memory implementation to prove the concept.