### PR TITLE
hierarchy test solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ So, we need to make any necessary changes to eliminate the need of the cache. Su
 
 The while loop in the "findTopLevelGroupId"method located in GroupModel.java file can make the heap space explode as there is an unknown number of levels beyond second level. Adding a "top_level_id" field in the database schema can serve as an alternative for that while loop because for every group we can store the top_level_id here.
 
-We can use a recursive CTE(common table expression) to get the value of the  top_level_id field
+We can use a recursive CTE(common table expression) or a self-join to get the value of the  top_level_id field

--- a/README.md
+++ b/README.md
@@ -40,3 +40,9 @@ So, we need to make any necessary changes to eliminate the need of the cache. Su
 
 1. Changes in the database structure
 2. Changes in the Java code
+
+## Proposed solutions
+
+The while loop in the "findTopLevelGroupId"method located in GroupModel.java file can make the heap space explode as there is an unknown number of levels beyond second level. Adding a "top_level_id" field in the database schema can serve as an alternative for that while loop because for every group we can store the top_level_id here.
+
+We can use a recursive CTE(common table expression) to get the value of the  top_level_id field

--- a/src/test/hierarchy/GroupModel.java
+++ b/src/test/hierarchy/GroupModel.java
@@ -43,6 +43,12 @@ public class GroupModel {
     }
 
     // otherwise it is a common folder deeper.
+
+    //This while loop can make the heap space explode as we are dealing with unlimited levels.
+    
+    /*An alternative for this is to add a top_level_id field in the database schema so for every child reference we can have an immediate parent reference
+     and there is no need to move through the entire tree*/
+
     while (true) {
       Group parent = groupMap.get(parentGroupId);
       if (groupMap.get(parent.getParentId()).getParentId() == null) {


### PR DESCRIPTION
The while loop in the "findTopLevelGroupId"method located in GroupModel.java file can make the heap space explode as there is an unknown number of levels beyond second level. Adding a "top_level_id" field in the database schema can serve as an alternative for that while loop because for every group we can store the top_level_id here and by a self-join we can refer that id